### PR TITLE
Resize chart width on view resize

### DIFF
--- a/org.openjdk.jmc.flightrecorder.ext.flamegraph/src/main/java/org/openjdk/jmc/flightrecorder/ext/flamegraph/views/page.html
+++ b/org.openjdk.jmc.flightrecorder.ext.flamegraph/src/main/java/org/openjdk/jmc/flightrecorder/ext/flamegraph/views/page.html
@@ -4,34 +4,46 @@
 	<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
 	<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/spiermar/d3-flame-graph@1.0.4/dist/d3.flameGraph.min.css">
 </head>
-<body>
+<body onresize="resizeFlameGraph()">
   <div id="chart"></div>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.10.0/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.13.0/d3.min.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.7.1/d3-tip.min.js"></script>
   <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/spiermar/d3-flame-graph@1.0.4/dist/d3.flameGraph.min.js"></script>
   <script type="text/javascript">
- 	
+
+ 	var flameGraph;
+ 	var currentJson;
+  	var viewWidth;
+
   	function processGraph(jsonObj){
-  	  		
-  		var flameGraph = d3.flameGraph()
-    	.width(960)
-      	.transitionDuration(750)
-      	.transitionEase(d3.easeCubic)
-      	.sort(true)
-	    .title("");
-	    
-		var tip = d3.tip()
+		windowSize();
+  		flameGraph = d3.flameGraph()
+				      	.width(viewWidth * 0.9)
+				      	.transitionDuration(750)
+				      	.transitionEase(d3.easeCubic)
+				      	.sort(true)
+					    .title("");
+  		var tip = d3.tip()
       		.direction("s")
       		.offset([8, 0])
       		.attr('class', 'd3-flame-graph-tip')
       		.html(function(d) { return "name: " + d.data.name + ", value: " + d.data.value; });
     	flameGraph.tooltip(tip);
-
-		d3.select("#chart")
-        	.datum(jsonObj)
-      		.call(flameGraph);
-    
+		currentJson = jsonObj;
+		d3.select("#chart").datum(jsonObj).call(flameGraph);
   	}
+
+  	function windowSize() {
+	  	viewWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+  	}
+  	
+  	function resizeFlameGraph() {
+  		if (flameGraph) {
+  			windowSize();
+	    	flameGraph.width(viewWidth * 0.9);
+			d3.select("#chart").datum(currentJson).call(flameGraph);
+    	}
+  	}  	
   </script>  
 </body>
 </html>

--- a/org.openjdk.jmc.flightrecorder.ext.flamegraph/src/main/java/org/openjdk/jmc/flightrecorder/ext/flamegraph/views/page.html
+++ b/org.openjdk.jmc.flightrecorder.ext.flamegraph/src/main/java/org/openjdk/jmc/flightrecorder/ext/flamegraph/views/page.html
@@ -1,49 +1,54 @@
 <!DOCTYPE html "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
+
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/spiermar/d3-flame-graph@1.0.4/dist/d3.flameGraph.min.css">
 </head>
+
 <body onresize="resizeFlameGraph()">
-  <div id="chart"></div>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.13.0/d3.min.js"></script>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.7.1/d3-tip.min.js"></script>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/spiermar/d3-flame-graph@1.0.4/dist/d3.flameGraph.min.js"></script>
-  <script type="text/javascript">
+	<div id="chart"></div>
+	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.13.0/d3.min.js"></script>
+	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.7.1/d3-tip.min.js"></script>
+	<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/spiermar/d3-flame-graph@1.0.4/dist/d3.flameGraph.min.js"></script>
+	<script type="text/javascript">
 
- 	var flameGraph;
- 	var currentJson;
-  	var viewWidth;
+		var flameGraph;
+		var currentJson;
 
-  	function processGraph(jsonObj){
-		windowSize();
-  		flameGraph = d3.flameGraph()
-				      	.width(viewWidth * 0.9)
-				      	.transitionDuration(750)
-				      	.transitionEase(d3.easeCubic)
-				      	.sort(true)
-					    .title("");
-  		var tip = d3.tip()
-      		.direction("s")
-      		.offset([8, 0])
-      		.attr('class', 'd3-flame-graph-tip')
-      		.html(function(d) { return "name: " + d.data.name + ", value: " + d.data.value; });
-    	flameGraph.tooltip(tip);
-		currentJson = jsonObj;
-		d3.select("#chart").datum(jsonObj).call(flameGraph);
-  	}
+		function processGraph(jsonObj) {
+			flameGraph = d3.flameGraph()
+				.width(windowSize() * 0.9)
+				.transitionDuration(750)
+				.transitionEase(d3.easeCubic)
+				.sort(true)
+				.title("");
+			var tip = d3.tip()
+				.direction("s")
+				.offset([8, 0])
+				.attr('class', 'd3-flame-graph-tip')
+				.html(function (d) { return "name: " + d.data.name + ", value: " + d.data.value; });
+			flameGraph.tooltip(tip);
+			currentJson = jsonObj;
+			d3.select("#chart")
+				.datum(jsonObj)
+				.call(flameGraph);
+		}
 
-  	function windowSize() {
-	  	viewWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
-  	}
-  	
-  	function resizeFlameGraph() {
-  		if (flameGraph) {
-  			windowSize();
-	    	flameGraph.width(viewWidth * 0.9);
-			d3.select("#chart").datum(currentJson).call(flameGraph);
-    	}
-  	}  	
-  </script>  
+		function windowSize() {
+			return Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+		}
+
+		function resizeFlameGraph() {
+			if (flameGraph) {
+				flameGraph.width(windowSize() * 0.9);
+				d3.select("#chart")
+					.datum(currentJson)
+					.call(flameGraph);
+			}
+		}  	
+		
+	</script>
 </body>
+
 </html>


### PR DESCRIPTION
Here's one way to solve fit on resize (https://github.com/thegreystone/jmc-flame-view/issues/8).

The chart width is set to 90% of the view width and this is applied on every browser resize.

I've looked at height resize also, but it doesn't look as well when applied, so width resize seems sufficient.